### PR TITLE
Bugfix: prefix hash symbol when missing from hex codes

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,8 @@ import { copyTextToClipboard } from '../lib/clipboard'
 import React from 'react'
 import Head from 'next/head'
 
+const validHexWithoutHashRegex = /^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+
 const Home: NextPage = () => {
   const router = useRouter()
 
@@ -69,6 +71,13 @@ const Home: NextPage = () => {
     resultMatchPercentage === 100
       ? 'exact match'
       : `${resultMatchPercentage.toFixed(2)}% match`
+
+  // The `nearest-color` library accepts a hex value _without_ the leading # when
+  // searching for the nearest match, which is nice from a user experience perspective,
+  // but not valid when we use it for styling purposes, so we'll patch it up here.
+  const validColorFromSearch = validHexWithoutHashRegex.test(searchedColor)
+    ? `#${searchedColor}`
+    : searchedColor
 
   return (
     <div className="min-h-screen">
@@ -160,11 +169,13 @@ const Home: NextPage = () => {
                           <div className="flex items-center pt-1 mt-1 border-0 border-t">
                             <div
                               className="w-12 h-8 mr-8 border border-black rounded cursor-pointer"
-                              style={{ backgroundColor: searchedColor }}
-                              onClick={() => handleSwatchClick(searchedColor)}
+                              style={{ backgroundColor: validColorFromSearch }}
+                              onClick={() =>
+                                handleSwatchClick(validColorFromSearch)
+                              }
                             />
                             <span className="italic text-gray-500">
-                              {searchedColor}
+                              {validColorFromSearch}
                             </span>
                           </div>
                         )}


### PR DESCRIPTION
The `nearest-color` library will accept hex codes without the leading `#` symbol (e.g. `000`), but we need the leading hash when rendering the corresponding color swatch, otherwise it looks like this:

<img width="645" alt="Screen Shot 2022-08-26 at 10 08 14 PM" src="https://user-images.githubusercontent.com/6512153/186881819-fe44c0ae-5743-4405-a27d-c7fb1dc317fc.png">

This PR checks for a valid-ish hex code (i.e. valid but missing the leading `#`), and adds the missing `#` to give us this:

<img width="628" alt="Screen Shot 2022-08-26 at 10 08 32 PM" src="https://user-images.githubusercontent.com/6512153/186881853-020c4306-ced4-42e2-9d4e-923fb9fdebbe.png">

So now the searched color's swatch renders correctly, and if we copy the searched code to clipboard it will be a valid hex code.

Fixes #2 